### PR TITLE
Feature/reverse search

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,8 @@ Or install it yourself as:
 
 ```ruby
 require "offline_geocoder"
-
 geocoder = OfflineGeocoder.new
-
 results = geocoder.search(51.5214588, -0.1729636)
-
 p results
 ```
 
@@ -40,6 +37,35 @@ The above code will output this:
 {:lat=>51.51116, :lon=>-0.18426, :name=>"Bayswater", :admin1=>"England", :admin2=>"Greater London", :cc=>"GB", :country=>"United Kingdom"}
 ```
 
+Alternatively, you can use named parameters when searching:
+
+```ruby
+results = geocoder.search(lat: 51.5214588, lon: -0.1729636)
+```
+
+### Searching for names or attributes
+
+You can search for names, countries and such. The first result will be
+returned.
+
+Searches are case sensitive and must match entirely. e.g. "York" will
+not find "New York", and "Cote dIvoire" will not match "Cote d'Ivoire".
+
+```ruby
+require "offline_geocoder"
+geocoder = OfflineGeocoder.new
+aus = geocoder.search(name: "Bayswater")
+p aus
+gb = geocoder.search(name: "Bayswater", country: "United Kingdom")
+p gb
+```
+
+The above code will output this:
+
+```ruby
+{:lat=>-37.85, :lon=>145.26667, :name=>"Bayswater", :admin1=>"Victoria", :admin2=>"Knox", :cc=>"AU", :country=>"Australia"}
+{:lat=>51.51116, :lon=>-0.18426, :name=>"Bayswater", :admin1=>"England", :admin2=>"Greater London", :cc=>"GB", :country=>"United Kingdom"}
+```
 
 ## Development
 

--- a/lib/offline_geocoder.rb
+++ b/lib/offline_geocoder.rb
@@ -36,16 +36,10 @@ class OfflineGeocoder
   end
 
   def search(query, lon = nil)
-    if lon
-      lat = query.to_f
-      lon = lon.to_f
-    elsif query.is_a? Hash
-      lat = query[:lat].to_f if query.include?(:lat)
-      lon = query[:lon].to_f if query.include?(:lon)
-    end
+    lat, lon = lon.nil? ? [query[:lat], query[:lon]] : [query, lon]
 
     if lat && lon
-      search_by_latlon(lat, lon)
+      search_by_latlon(lat.to_f, lon.to_f)
     else
       search_by_attr(query)
     end

--- a/lib/offline_geocoder.rb
+++ b/lib/offline_geocoder.rb
@@ -63,6 +63,6 @@ class OfflineGeocoder
   end
 
   def search_by_attr(query = {})
-    @@cities.select { |object|  object >= query }.first
+    @@cities.select { |object| object >= query }.first
   end
 end

--- a/lib/offline_geocoder.rb
+++ b/lib/offline_geocoder.rb
@@ -36,12 +36,18 @@ class OfflineGeocoder
   end
 
   def search(query, lon = nil)
-    if query.is_a? Hash
-      search_by_attr(query)
-    elsif lon
+    if lon
       lat = query.to_f
       lon = lon.to_f
-      @@cities[@@tree.nearest([lat, lon]).data.to_i]
+    elsif query.is_a? Hash
+      lat = query[:lat].to_f if query.include?(:lat)
+      lon = query[:lon].to_f if query.include?(:lon)
+    end
+
+    if lat && lon
+      search_by_latlon(lat, lon)
+    else
+      search_by_attr(query)
     end
   end
 
@@ -51,6 +57,10 @@ class OfflineGeocoder
   end
 
   private
+
+  def search_by_latlon(lat, lon)
+    @@cities[@@tree.nearest([lat, lon]).data.to_i]
+  end
 
   def search_by_attr(query = {})
     @@cities.select { |object|  object >= query }.first

--- a/spec/offline_geocoder_spec.rb
+++ b/spec/offline_geocoder_spec.rb
@@ -1,6 +1,18 @@
 require 'spec_helper'
 
 describe OfflineGeocoder do
+  let(:bilbao_result) do
+    {
+      lat: 43.26271,
+      lon: -2.92528,
+      name: "Bilbao",
+      admin1: "Basque Country",
+      admin2: "Bizkaia",
+      cc: "ES",
+      country: "Spain"
+    }
+  end
+
   it 'has a version number' do
     expect(OfflineGeocoder::VERSION).not_to be nil
   end
@@ -8,26 +20,18 @@ describe OfflineGeocoder do
   it 'returns correct results' do
     geocoder = OfflineGeocoder.new
     result = geocoder.search(43.26, -2.92)
-    expect(result).to eq({lat: 43.26271,
-                          lon: -2.92528,
-                          name: "Bilbao",
-                          admin1: "Basque Country",
-                          admin2: "Bizkaia",
-                          cc: "ES",
-                          country: "Spain"
-                         })
+    expect(result).to eq(bilbao_result)
   end
 
   it 'accepts strings as a parameter' do
     geocoder = OfflineGeocoder.new
     result = geocoder.search("43.26", "-2.92")
-    expect(result).to eq({lat: 43.26271,
-                          lon: -2.92528,
-                          name: "Bilbao",
-                          admin1: "Basque Country",
-                          admin2: "Bizkaia",
-                          cc: "ES",
-                          country: "Spain"
-                         })
+    expect(result).to eq(bilbao_result)
+  end
+
+  it 'searches by name' do
+    geocoder = OfflineGeocoder.new
+    result = geocoder.search("Bilbao")
+    expect(result).to eq(bilbao_result)
   end
 end

--- a/spec/offline_geocoder_spec.rb
+++ b/spec/offline_geocoder_spec.rb
@@ -5,11 +5,11 @@ describe OfflineGeocoder do
     {
       lat: 43.26271,
       lon: -2.92528,
-      name: "Bilbao",
-      admin1: "Basque Country",
-      admin2: "Bizkaia",
-      cc: "ES",
-      country: "Spain"
+      name: 'Bilbao',
+      admin1: 'Basque Country',
+      admin2: 'Bizkaia',
+      cc: 'ES',
+      country: 'Spain'
     }
   end
 
@@ -25,33 +25,33 @@ describe OfflineGeocoder do
   end
 
   it 'accepts strings as a parameter' do
-    result = subject.search("43.26", "-2.92")
+    result = subject.search('43.26', '-2.92')
     expect(result).to eq(bilbao_result)
   end
 
   it 'accepts hash as a parameter' do
-    result = subject.search(lat: "43.26", lon: "-2.92")
+    result = subject.search(lat: '43.26', lon: '-2.92')
     expect(result).to eq(bilbao_result)
   end
 
   it 'searches by name' do
-    result = subject.search(name: "Bilbao")
+    result = subject.search(name: 'Bilbao')
     expect(result).to eq(bilbao_result)
   end
 
   # Not a requirement, but a test to document implemented behaviour
   it 'searches are case sensitive' do
-    result = subject.search(name: "bilbao")
+    result = subject.search(name: 'bilbao')
     expect(result).not_to eq(bilbao_result)
   end
 
   it 'returns the first match' do
-    result = subject.search(name: "York", country: "United Kingdom")
-    expect(result[:country]).to eq("United Kingdom")
+    result = subject.search(name: 'York', country: 'United Kingdom')
+    expect(result[:country]).to eq('United Kingdom')
   end
 
   it 'searches by multiple attributes' do
-    result = subject.search(name: "York", country: "United Kingdom")
-    expect(result[:country]).to eq("United Kingdom")
+    result = subject.search(name: 'York', country: 'United Kingdom')
+    expect(result[:country]).to eq('United Kingdom')
   end
 end

--- a/spec/offline_geocoder_spec.rb
+++ b/spec/offline_geocoder_spec.rb
@@ -13,25 +13,40 @@ describe OfflineGeocoder do
     }
   end
 
+  let(:subject) { OfflineGeocoder.new }
+
   it 'has a version number' do
     expect(OfflineGeocoder::VERSION).not_to be nil
   end
 
   it 'returns correct results' do
-    geocoder = OfflineGeocoder.new
-    result = geocoder.search(43.26, -2.92)
+    result = subject.search(43.26, -2.92)
     expect(result).to eq(bilbao_result)
   end
 
   it 'accepts strings as a parameter' do
-    geocoder = OfflineGeocoder.new
-    result = geocoder.search("43.26", "-2.92")
+    result = subject.search("43.26", "-2.92")
     expect(result).to eq(bilbao_result)
   end
 
   it 'searches by name' do
-    geocoder = OfflineGeocoder.new
-    result = geocoder.search("Bilbao")
+    result = subject.search(name: "Bilbao")
     expect(result).to eq(bilbao_result)
+  end
+
+  # Not a requirement, but a test to document implemented behaviour
+  it 'searches are case sensitive' do
+    result = subject.search(name: "bilbao")
+    expect(result).not_to eq(bilbao_result)
+  end
+
+  it 'returns the first match' do
+    result = subject.search(name: "York", country: "United Kingdom")
+    expect(result[:country]).to eq("United Kingdom")
+  end
+
+  it 'searches by multiple attributes' do
+    result = subject.search(name: "York", country: "United Kingdom")
+    expect(result[:country]).to eq("United Kingdom")
   end
 end

--- a/spec/offline_geocoder_spec.rb
+++ b/spec/offline_geocoder_spec.rb
@@ -29,6 +29,11 @@ describe OfflineGeocoder do
     expect(result).to eq(bilbao_result)
   end
 
+  it 'accepts hash as a parameter' do
+    result = subject.search(lat: "43.26", lon: "-2.92")
+    expect(result).to eq(bilbao_result)
+  end
+
   it 'searches by name' do
     result = subject.search(name: "Bilbao")
     expect(result).to eq(bilbao_result)


### PR DESCRIPTION
I am in need of a simple, yet speedy reverse-reverse geocoding. Where I have the names of places and know some context and then need an approximate lat/lon pair for that. 

This patch keeps the original behaviour but adds some new `search` features. 

```ruby
aus = geocoder.search(name: "Bayswater")
gb = geocoder.search(name: "Bayswater", country: "United Kingdom")
```

To keep the old interface, but also allow the new keyword based interface consistent with lat/lon searches, it introduces:

```ruby
geocoder.search(lat: 51.5214588, lon: -0.1729636)
```

I've done some benchmarks, using 500 rounds:

before:
```
intialization
  0.000132   0.000009   0.000141 (  0.000135)
reverse search
  0.003411   0.000000   0.003411 (  0.003411)
textual search
```
after this PR:
```
intialization
  0.000058   0.000006   0.000064 (  0.000060)
reverse search
  0.001089   0.000000   0.001089 (  0.001089)
textual search
 17.934658   0.000176  17.934834 ( 17.937116)
```

Notable is the poor performance of textual search compared to the bt_tree search. Which is quite obvious as the textual search is `O(n+m)` at best. The refactoring that was required to introduce the new interface does improve the performance of the initialization a little and the search then as well.

I would expect memory consumption to grow a tiny bit, since we're storing an array-of-hashes instead of an array-of-arrays in the `@@cities` table after this PR and hashes are a littlebit more complex. But I expect this to be (i) neglegible and (ii) different over the ruby interpreters/versions.

Note that an intermediate commit in this PR, introduces a very naive search, using substrings, this is also benchmarked, but not to my liking. So it is removed in the result of this PR. I've left the commit in, for reference. Please let me know if you wish me to rebase&remove that. Alternative could be to use [FuzzyMatch](https://github.com/seamusabshere/fuzzy_match) but that has a poor performance and the results were not to my liking: often unexpected.