### PR TITLE
Feature/csv parse

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,8 @@ Or install it yourself as:
 
 ```ruby
 require "offline_geocoder"
-
 geocoder = OfflineGeocoder.new
-
 results = geocoder.search(51.5214588, -0.1729636)
-
 p results
 ```
 
@@ -40,6 +37,35 @@ The above code will output this:
 {:lat=>51.51116, :lon=>-0.18426, :name=>"Bayswater", :admin1=>"England", :admin2=>"Greater London", :cc=>"GB", :country=>"United Kingdom"}
 ```
 
+Alternatively, you can use named parameters when searching:
+
+```ruby
+results = geocoder.search(lat: 51.5214588, lon: -0.1729636)
+```
+
+### Searching for names or attributes
+
+You can search for names, countries and such. The first result will be
+returned.
+
+Searches are case sensitive and must match entirely. e.g. "York" will
+not find "New York", and "Cote dIvoire" will not match "Cote d'Ivoire".
+
+```ruby
+require "offline_geocoder"
+geocoder = OfflineGeocoder.new
+aus = geocoder.search(name: "Bayswater")
+p aus
+gb = geocoder.search(name: "Bayswater", country: "United Kingdom")
+p gb
+```
+
+The above code will output this:
+
+```ruby
+{:lat=>-37.85, :lon=>145.26667, :name=>"Bayswater", :admin1=>"Victoria", :admin2=>"Knox", :cc=>"AU", :country=>"Australia"}
+{:lat=>51.51116, :lon=>-0.18426, :name=>"Bayswater", :admin1=>"England", :admin2=>"Greater London", :cc=>"GB", :country=>"United Kingdom"}
+```
 
 ## Development
 

--- a/lib/offline_geocoder.rb
+++ b/lib/offline_geocoder.rb
@@ -36,16 +36,10 @@ class OfflineGeocoder
   end
 
   def search(query, lon = nil)
-    if lon
-      lat = query.to_f
-      lon = lon.to_f
-    elsif query.is_a? Hash
-      lat = query[:lat].to_f if query.include?(:lat)
-      lon = query[:lon].to_f if query.include?(:lon)
-    end
+    lat, lon = lon.nil? ? [query[:lat], query[:lon]] : [query, lon]
 
     if lat && lon
-      search_by_latlon(lat, lon)
+      search_by_latlon(lat.to_f, lon.to_f)
     else
       search_by_attr(query)
     end

--- a/lib/offline_geocoder.rb
+++ b/lib/offline_geocoder.rb
@@ -3,7 +3,7 @@ require "csv"
 require "geokdtree"
 
 class OfflineGeocoder
-  CSV_PATH = File.expand_path("../../og_cities1000.csv", __FILE__)
+  CSV_PATH = File.expand_path('../og_cities1000.csv', __dir__)
 
   def initialize
     unless defined? @@cities

--- a/lib/offline_geocoder.rb
+++ b/lib/offline_geocoder.rb
@@ -63,6 +63,6 @@ class OfflineGeocoder
   end
 
   def search_by_attr(query = {})
-    @@cities.select { |object|  object >= query }.first
+    @@cities.select { |object| object >= query }.first
   end
 end

--- a/lib/offline_geocoder.rb
+++ b/lib/offline_geocoder.rb
@@ -3,33 +3,22 @@ require "csv"
 require "geokdtree"
 
 class OfflineGeocoder
+  CSV_PATH = File.expand_path("../../og_cities1000.csv", __FILE__)
+
   def initialize
     unless defined? @@cities
       @@cities = []
       @@tree = Geokdtree::Tree.new(2)
+      @@table = []
       index = 0
-      csv_path = File.expand_path("../../og_cities1000.csv", __FILE__)
-      lines = File.read(csv_path).split("\n")
-      @@fields = lines[0].split(',').collect(&:to_sym)
-      lines[1..-1].each {|line|
-        parsed_line =
-          if line.include?('"')
-            CSV.parse(line)[0]
-          else
-            line.split(',')
-          end
-        parsed_line[0] = parsed_line[0].to_f
-        parsed_line[1] = parsed_line[1].to_f
-
-        line_as_h = {}
-        parsed_line.each_with_index do |value, col|
-          line_as_h[@@fields[col]] = value
-        end
-
-        @@cities << line_as_h
-        @@tree.insert([line_as_h[:lat], line_as_h[:lon]], index)
+      CSV.foreach(CSV_PATH, headers: true, header_converters: :symbol) do |row|
+        as_hash = row.to_h
+        as_hash[:lat] = as_hash[:lat].to_f
+        as_hash[:lon] = as_hash[:lon].to_f
+        @@tree.insert([row[:lat], row[:lon]], index)
+        @@table << as_hash
         index += 1
-      }
+      end
 
       return nil
     end
@@ -53,10 +42,10 @@ class OfflineGeocoder
   private
 
   def search_by_latlon(lat, lon)
-    @@cities[@@tree.nearest([lat, lon]).data.to_i]
+    @@table[@@tree.nearest([lat, lon]).data.to_i].to_h
   end
 
   def search_by_attr(query = {})
-    @@cities.select { |object| object >= query }.first
+    @@table.select { |object| object >= query }.first
   end
 end

--- a/lib/offline_geocoder.rb
+++ b/lib/offline_geocoder.rb
@@ -36,12 +36,18 @@ class OfflineGeocoder
   end
 
   def search(query, lon = nil)
-    if query.is_a? Hash
-      search_by_attr(query)
-    elsif lon
+    if lon
       lat = query.to_f
       lon = lon.to_f
-      @@cities[@@tree.nearest([lat, lon]).data.to_i]
+    elsif query.is_a? Hash
+      lat = query[:lat].to_f if query.include?(:lat)
+      lon = query[:lon].to_f if query.include?(:lon)
+    end
+
+    if lat && lon
+      search_by_latlon(lat, lon)
+    else
+      search_by_attr(query)
     end
   end
 
@@ -51,6 +57,10 @@ class OfflineGeocoder
   end
 
   private
+
+  def search_by_latlon(lat, lon)
+    @@cities[@@tree.nearest([lat, lon]).data.to_i]
+  end
 
   def search_by_attr(query = {})
     @@cities.select { |object|  object >= query }.first

--- a/spec/offline_geocoder_spec.rb
+++ b/spec/offline_geocoder_spec.rb
@@ -1,6 +1,18 @@
 require 'spec_helper'
 
 describe OfflineGeocoder do
+  let(:bilbao_result) do
+    {
+      lat: 43.26271,
+      lon: -2.92528,
+      name: "Bilbao",
+      admin1: "Basque Country",
+      admin2: "Bizkaia",
+      cc: "ES",
+      country: "Spain"
+    }
+  end
+
   it 'has a version number' do
     expect(OfflineGeocoder::VERSION).not_to be nil
   end
@@ -8,26 +20,18 @@ describe OfflineGeocoder do
   it 'returns correct results' do
     geocoder = OfflineGeocoder.new
     result = geocoder.search(43.26, -2.92)
-    expect(result).to eq({lat: 43.26271,
-                          lon: -2.92528,
-                          name: "Bilbao",
-                          admin1: "Basque Country",
-                          admin2: "Bizkaia",
-                          cc: "ES",
-                          country: "Spain"
-                         })
+    expect(result).to eq(bilbao_result)
   end
 
   it 'accepts strings as a parameter' do
     geocoder = OfflineGeocoder.new
     result = geocoder.search("43.26", "-2.92")
-    expect(result).to eq({lat: 43.26271,
-                          lon: -2.92528,
-                          name: "Bilbao",
-                          admin1: "Basque Country",
-                          admin2: "Bizkaia",
-                          cc: "ES",
-                          country: "Spain"
-                         })
+    expect(result).to eq(bilbao_result)
+  end
+
+  it 'searches by name' do
+    geocoder = OfflineGeocoder.new
+    result = geocoder.search("Bilbao")
+    expect(result).to eq(bilbao_result)
   end
 end

--- a/spec/offline_geocoder_spec.rb
+++ b/spec/offline_geocoder_spec.rb
@@ -5,11 +5,11 @@ describe OfflineGeocoder do
     {
       lat: 43.26271,
       lon: -2.92528,
-      name: "Bilbao",
-      admin1: "Basque Country",
-      admin2: "Bizkaia",
-      cc: "ES",
-      country: "Spain"
+      name: 'Bilbao',
+      admin1: 'Basque Country',
+      admin2: 'Bizkaia',
+      cc: 'ES',
+      country: 'Spain'
     }
   end
 
@@ -25,33 +25,33 @@ describe OfflineGeocoder do
   end
 
   it 'accepts strings as a parameter' do
-    result = subject.search("43.26", "-2.92")
+    result = subject.search('43.26', '-2.92')
     expect(result).to eq(bilbao_result)
   end
 
   it 'accepts hash as a parameter' do
-    result = subject.search(lat: "43.26", lon: "-2.92")
+    result = subject.search(lat: '43.26', lon: '-2.92')
     expect(result).to eq(bilbao_result)
   end
 
   it 'searches by name' do
-    result = subject.search(name: "Bilbao")
+    result = subject.search(name: 'Bilbao')
     expect(result).to eq(bilbao_result)
   end
 
   # Not a requirement, but a test to document implemented behaviour
   it 'searches are case sensitive' do
-    result = subject.search(name: "bilbao")
+    result = subject.search(name: 'bilbao')
     expect(result).not_to eq(bilbao_result)
   end
 
   it 'returns the first match' do
-    result = subject.search(name: "York", country: "United Kingdom")
-    expect(result[:country]).to eq("United Kingdom")
+    result = subject.search(name: 'York', country: 'United Kingdom')
+    expect(result[:country]).to eq('United Kingdom')
   end
 
   it 'searches by multiple attributes' do
-    result = subject.search(name: "York", country: "United Kingdom")
-    expect(result[:country]).to eq("United Kingdom")
+    result = subject.search(name: 'York', country: 'United Kingdom')
+    expect(result[:country]).to eq('United Kingdom')
   end
 end

--- a/spec/offline_geocoder_spec.rb
+++ b/spec/offline_geocoder_spec.rb
@@ -13,25 +13,40 @@ describe OfflineGeocoder do
     }
   end
 
+  let(:subject) { OfflineGeocoder.new }
+
   it 'has a version number' do
     expect(OfflineGeocoder::VERSION).not_to be nil
   end
 
   it 'returns correct results' do
-    geocoder = OfflineGeocoder.new
-    result = geocoder.search(43.26, -2.92)
+    result = subject.search(43.26, -2.92)
     expect(result).to eq(bilbao_result)
   end
 
   it 'accepts strings as a parameter' do
-    geocoder = OfflineGeocoder.new
-    result = geocoder.search("43.26", "-2.92")
+    result = subject.search("43.26", "-2.92")
     expect(result).to eq(bilbao_result)
   end
 
   it 'searches by name' do
-    geocoder = OfflineGeocoder.new
-    result = geocoder.search("Bilbao")
+    result = subject.search(name: "Bilbao")
     expect(result).to eq(bilbao_result)
+  end
+
+  # Not a requirement, but a test to document implemented behaviour
+  it 'searches are case sensitive' do
+    result = subject.search(name: "bilbao")
+    expect(result).not_to eq(bilbao_result)
+  end
+
+  it 'returns the first match' do
+    result = subject.search(name: "York", country: "United Kingdom")
+    expect(result[:country]).to eq("United Kingdom")
+  end
+
+  it 'searches by multiple attributes' do
+    result = subject.search(name: "York", country: "United Kingdom")
+    expect(result[:country]).to eq("United Kingdom")
   end
 end

--- a/spec/offline_geocoder_spec.rb
+++ b/spec/offline_geocoder_spec.rb
@@ -29,6 +29,11 @@ describe OfflineGeocoder do
     expect(result).to eq(bilbao_result)
   end
 
+  it 'accepts hash as a parameter' do
+    result = subject.search(lat: "43.26", lon: "-2.92")
+    expect(result).to eq(bilbao_result)
+  end
+
   it 'searches by name' do
     result = subject.search(name: "Bilbao")
     expect(result).to eq(bilbao_result)


### PR DESCRIPTION
This is a followup of #12. It therefore builds on top of that PR.

This PR changes the parsing and therefore the initialization from in-ruby string parsing to the CSV parser. On most ruby-interpreters this will be (much) faster. As can be seen in the benchmark below.

More important, howerver, is that the initialization method becomes much smaller and easier to read.

```
───────┬─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
       │ File: bm_before.txt
───────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   1   │ intialization
   2   │   0.000132   0.000009   0.000141 (  0.000135)
   3   │ reverse search
   4   │   0.003411   0.000000   0.003411 (  0.003411)
   5   │ textual search
───────┴─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
───────┬─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
       │ File: bm_csv_parser.txt
───────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   1   │ intialization
   2   │   0.000065   0.000001   0.000066 (  0.000063)
   3   │ reverse search
   4   │   0.001173   0.000030   0.001203 (  0.001203)
   5   │ textual search
   6   │  23.096894   0.003981  23.100875 ( 23.102992)
───────┴─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
```